### PR TITLE
adds namespace to chart resources that require it

### DIFF
--- a/charts/sidecar-cleaner/templates/deployment.yaml
+++ b/charts/sidecar-cleaner/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "sidecar-cleaner.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sidecar-cleaner.labels" . | nindent 4 }}
 spec:

--- a/charts/sidecar-cleaner/templates/serviceaccount.yaml
+++ b/charts/sidecar-cleaner/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "sidecar-cleaner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "sidecar-cleaner.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Hi there, thanks for the repo - been using it for some time now to properly cull my cronjobs.

However, ran into this bug when trying to install it into separate namespaces via `helm template`.
Realized that a few resources are missing the namespace being declared.

What happens is you output the yaml for a different namespace, but all of the resources are created in `default`, but the role binding is binding the service account against the release namespace.

`helm template ./charts/sidecar-cleaner -n foobar`